### PR TITLE
registration and login routes

### DIFF
--- a/.bolt/config.json
+++ b/.bolt/config.json
@@ -1,3 +1,0 @@
-{
-  "template": "node"
-}

--- a/src/middleware/audit.ts
+++ b/src/middleware/audit.ts
@@ -11,36 +11,22 @@ export const auditLog = (action: string) => {
     res: Response,
     next: NextFunction
   ): Promise<void> => {
-    // The original response.end function
-    const originalEnd = res.end;
-    
-    // Replace the response.end function with our wrapped version
-    res.end = function(chunk?: any, encoding?: string): Response {
-      // Call the original end function
-      originalEnd.call(this, chunk, encoding);
-      
-      // Only log if user is authenticated
-      if (req.user) {
-        try {
-          // Create the audit log
-          AuditLog.create({
-            user_id: req.user.id,
-            action,
-            description: `${req.method} ${req.originalUrl} - Status: ${res.statusCode}`,
-            ip_address: req.ip || req.socket.remoteAddress || '',
-            timestamp: new Date()
-          }).catch((err) => {
-            console.error('Error creating audit log:', err);
-          });
-        } catch (error) {
-          console.error('Error in audit log middleware:', error);
-        }
+    res.on('finish', () => {
+      const user = (req as any).user;
+
+      if (user) {
+        AuditLog.create({
+          user_id: user.id,
+          action,
+          description: `${req.method} ${req.originalUrl} - Status: ${res.statusCode}`,
+          ip_address: req.ip || req.socket.remoteAddress || '',
+          timestamp: new Date(),
+        }).catch((err) => {
+          console.error('Error creating audit log:', err);
+        });
       }
-      
-      // Return the response object
-      return res;
-    };
-    
+    });
+
     next();
   };
 };

--- a/src/middleware/error.ts
+++ b/src/middleware/error.ts
@@ -1,9 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import { logger } from '../utils/logger';
 
-interface AppError extends Error {
-  statusCode?: number;
-  isOperational?: boolean;
+export interface AppError extends Error {
+  statusCode: number;
+  isOperational: boolean;
 }
 
 /**

--- a/src/middleware/validation.ts
+++ b/src/middleware/validation.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import { validationResult, ValidationChain } from 'express-validator';
+import { validationResult, ValidationChain, ValidationError } from 'express-validator';
 
 /**
  * Middleware to validate request input
@@ -17,10 +17,18 @@ export const validate = (validations: ValidationChain[]) => {
     }
 
     // Format validation errors
-    const formattedErrors = errors.array().map(error => ({
-      field: error.param,
-      message: error.msg
-    }));
+    const formattedErrors = errors.array().map((error: ValidationError) => {
+      if ('param' in error) {
+        return {
+          field: error.param,
+          message: error.msg
+        };
+      }
+      return {
+        field: 'unknown',
+        message: error.msg
+      };
+    });
 
     return res.status(400).json({ 
       message: 'Validation failed', 

--- a/src/models/Upload.ts
+++ b/src/models/Upload.ts
@@ -24,17 +24,17 @@ const uploadSchema = new Schema<IUpload>({
     required: true 
   },
   related_to: {
-    type: { 
-      type: String, 
+    type: {
+      type: String,
       required: true,
       enum: ['assessment', 'form', 'other']
     },
-    id: { 
-      type: Schema.Types.ObjectId, 
+    id: {
+      type: Schema.Types.ObjectId,
       required: true,
       refPath: 'related_to.type'
     }
-  },
+  } as any, // Use 'as any' to bypass type incompatibility
   created_at: { 
     type: Date, 
     default: Date.now 

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -59,4 +59,4 @@ router.post(
   changePassword
 );
 
-export default router;</boltAction type="file" filePath="src/routes/authRoutes.ts">
+export default router;

--- a/src/utils/jwt.ts
+++ b/src/utils/jwt.ts
@@ -1,15 +1,16 @@
-import jwt from 'jsonwebtoken';
+import jwt, { Secret } from 'jsonwebtoken';
 import { IUser } from '../models/User';
 import { TokenType } from '../types/models';
 import AuthToken from '../models/AuthToken';
 
 // Secret keys
-const ACCESS_TOKEN_SECRET = process.env.JWT_SECRET || 'your_jwt_secret_key_here';
-const REFRESH_TOKEN_SECRET = `${ACCESS_TOKEN_SECRET}_refresh`;
+const ACCESS_TOKEN_SECRET: Secret = process.env.JWT_SECRET || 'your_jwt_secret_key_here';
+const REFRESH_TOKEN_SECRET: Secret = `${ACCESS_TOKEN_SECRET}_refresh`;
+
 
 // Token expiration
-const ACCESS_TOKEN_EXPIRATION = process.env.JWT_ACCESS_EXPIRATION || '15m';
-const REFRESH_TOKEN_EXPIRATION = process.env.JWT_REFRESH_EXPIRATION || '7d';
+const ACCESS_TOKEN_EXPIRATION = ms(process.env.JWT_ACCESS_EXPIRATION || '15m') / 1000; // Convert to seconds
+const REFRESH_TOKEN_EXPIRATION = ms(process.env.JWT_REFRESH_EXPIRATION || '7d') / 1000; // Convert to seconds
 
 // Generate tokens
 export const generateAccessToken = (user: IUser): string => {
@@ -20,7 +21,7 @@ export const generateAccessToken = (user: IUser): string => {
       county: user.county
     }, 
     ACCESS_TOKEN_SECRET, 
-    { expiresIn: ACCESS_TOKEN_EXPIRATION }
+    { expiresIn: Math.floor(ACCESS_TOKEN_EXPIRATION) }
   );
 };
 
@@ -28,7 +29,7 @@ export const generateRefreshToken = (user: IUser): string => {
   return jwt.sign(
     { id: user._id }, 
     REFRESH_TOKEN_SECRET, 
-    { expiresIn: REFRESH_TOKEN_EXPIRATION }
+    { expiresIn: Math.floor(REFRESH_TOKEN_EXPIRATION) }
   );
 };
 


### PR DESCRIPTION
This pull request includes several updates to improve code quality, enhance type safety, and simplify logic across middleware, models, and utility files. The most important changes include refactoring the audit logging middleware, improving type definitions, enhancing validation error handling, and updating JWT token expiration logic.

### Middleware Updates:
* Refactored the audit logging middleware to simplify the logic by using the `res.on('finish')` event instead of overriding `res.end`. This ensures audit logs are created only after the response finishes. (`src/middleware/audit.ts`, [src/middleware/audit.tsL14-R28](diffhunk://#diff-778ac1ec9387def802c4e4fec9b816a2d72d0838ef01826e0457043b80706a2fL14-R28))
* Made `AppError` properties (`statusCode` and `isOperational`) mandatory in the error middleware to improve type safety. (`src/middleware/error.ts`, [src/middleware/error.tsL4-R6](diffhunk://#diff-3215f3d10867926c50e04787004d19339dcfdd3a36ed5a278e6bb7c1b1806437L4-R6))
* Enhanced validation middleware by explicitly typing `ValidationError` and providing a fallback for unknown error parameters in the formatted error response. (`src/middleware/validation.ts`, [[1]](diffhunk://#diff-62017acd8e2080c9cd38c0b6c3d9a304aeb9700804bc339c87d6f605adca07c9L2-R2) [[2]](diffhunk://#diff-62017acd8e2080c9cd38c0b6c3d9a304aeb9700804bc339c87d6f605adca07c9L20-R31)

### Model and Schema Adjustments:
* Added a type assertion (`as any`) to bypass type incompatibility in the `Upload` schema's `related_to` property. (`src/models/Upload.ts`, [src/models/Upload.tsL37-R37](diffhunk://#diff-a120fe4f2f1bdc7915125898c9a178c4788ce7625ae8aaba281c62ee3d69a682L37-R37))

### Utility Enhancements:
* Updated JWT utility to use the `ms` library for converting expiration times to seconds and rounded them down using `Math.floor` for consistency. Also added explicit `Secret` type annotations for JWT secrets. (`src/utils/jwt.ts`, [[1]](diffhunk://#diff-bc3253061283423c721c833f262624f2ba8b6073381c5122cc6671b500cfc743L1-R13) [[2]](diffhunk://#diff-bc3253061283423c721c833f262624f2ba8b6073381c5122cc6671b500cfc743L23-R32)